### PR TITLE
Adds support to match Spotify tracks to Tidal tracks and to playback …

### DIFF
--- a/mopidy_tidal/__init__.py
+++ b/mopidy_tidal/__init__.py
@@ -30,6 +30,9 @@ class Extension(ext.Extension):
         schema['username'] = config.String()
         schema['password'] = config.Secret()
         schema['quality'] = config.String(choices=["LOSSLESS", "HIGH", "LOW"])
+        schema['spotify_proxy'] = config.Boolean(optional=True)
+        schema['spotify_client_id'] = config.String(optional=True)
+        schema['spotify_client_secret'] = config.String(optional=True)
         return schema
 
     def setup(self, registry):

--- a/mopidy_tidal/backend.py
+++ b/mopidy_tidal/backend.py
@@ -25,7 +25,10 @@ class TidalBackend(ThreadingActor, backend.Backend):
                                                        backend=self)
         self.library = library.TidalLibraryProvider(backend=self)
         self.playlists = playlists.TidalPlaylistsProvider(backend=self)
-        self.uri_schemes = ['tidal']
+        if config['tidal']['spotify_proxy']:
+            self.uri_schemes = ['tidal', 'spotify']
+        else:
+            self.uri_schemes = ['tidal']
 
     def on_start(self):
         quality = self._config['tidal']['quality']

--- a/mopidy_tidal/ext.conf
+++ b/mopidy_tidal/ext.conf
@@ -3,3 +3,6 @@ enabled = true
 username=
 password=
 quality=LOSSLESS
+spotify_proxy = false
+spotify_client_id = ""
+spotify_client_secret = ""

--- a/mopidy_tidal/library.py
+++ b/mopidy_tidal/library.py
@@ -18,6 +18,7 @@ from mopidy_tidal.search import tidal_search
 
 from mopidy_tidal.utils import apply_watermark
 
+from mopidy_tidal.spotify_proxy import SpotifyProxy
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +46,11 @@ class TidalLibraryProvider(backend.LibraryProvider):
         self.lru_artist_img = LruCache()
         self.lru_album_img = LruCache()
         self.track_cache = Cache()
+        self.config = kwargs["backend"]._config
+        if self.config["tidal"]["spotify_proxy"]:
+            self.spotify_proxy = SpotifyProxy(str(self.config["tidal"]["spotify_client_id"]), 
+                                              str(self.config["tidal"]["spotify_client_secret"]))
+            
 
     def get_distinct(self, field, query=None):
         logger.debug("Browsing distinct %s with query %r", field, query)
@@ -88,7 +94,6 @@ class TidalLibraryProvider(backend.LibraryProvider):
         session = self.backend._session
 
         # summaries
-
         if uri == self.root_directory.uri:
             return ref_models_mappers.create_root()
 
@@ -205,6 +210,13 @@ class TidalLibraryProvider(backend.LibraryProvider):
         tracks = []
         for uri in uris:
             parts = uri.split(':')
+            logger.info('URI: %s', uri)
+            if uri.startswith('spotify:track:'):
+                info = self.spotify_proxy.get_song_info(uri)
+                if info is not None:
+                    result = self.search(query={"track_name": [info["title"] + " " + " ".join(info["artists"])]})
+                    if len(result.tracks) > 0:
+                        tracks.append(result.tracks[0])
             if uri.startswith('tidal:track:'):
                 if uri in self.track_cache:
                     tracks.append(self.track_cache[uri])

--- a/mopidy_tidal/spotify_proxy.py
+++ b/mopidy_tidal/spotify_proxy.py
@@ -1,0 +1,23 @@
+import spotipy
+from spotipy.oauth2 import SpotifyClientCredentials
+
+class SpotifyProxy:
+    def __init__(self, client_id, client_secret):
+        self.set_credentials(client_id, client_secret)
+        
+    def set_credentials(self, client_id, client_secret):
+        self.credentials = SpotifyClientCredentials(
+            client_id=client_id, 
+            client_secret=client_secret
+        )
+
+    def get_song_info(self, lz_uri):
+        spotify = spotipy.Spotify(client_credentials_manager = self.credentials)
+        results = spotify.tracks([lz_uri])
+        if len(results['tracks']) > 0:
+            track = results['tracks'][-1]
+            title = track["name"]
+            artists = [a["name"] for a in track["artists"]]
+            return {"title": title, "artists": artists}
+        else:
+            return None

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         'Pykka >= 1.1',
         'tidalapi >= 0.6.7,<0.7.0',
         'requests >= 2.0.0',
+        'spotipy >= 2.16.0'
     ],
     entry_points={
         'mopidy.ext': [


### PR DESCRIPTION
…them via Tidal in the chosen quality. Is only enabled by setting: tidal -> spotify_proxy = true.

Also tidal -> spotify_client_id and tidal -> spotify_client_secret have to be added additionally inside the config. Works with free spotify accounts.